### PR TITLE
Fixed warning about "Default-568h@2x-568h@2x"

### DIFF
--- a/dospad-Info.plist
+++ b/dospad-Info.plist
@@ -8,8 +8,7 @@
 	<string>DOSPAD</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
-	
-		<key>CFBundleIconFile</key>
+	<key>CFBundleIconFile</key>
 	<string>Icon-iPhone-57.png</string>
 	<key>CFBundleIconFiles</key>
 	<array>
@@ -56,8 +55,6 @@
 			<true/>
 		</dict>
 	</dict>
-	
-	
 	<key>CFBundleIdentifier</key>
 	<string>8HLDK844H7.net.litchie.dospad</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -79,7 +76,7 @@
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchImageFile~iphone</key>
-	<string>Default-568h@2x</string>
+	<string>Default</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<dict>
 		<key>armv7</key>


### PR DESCRIPTION
When compiling target "dospad", Xcode issues a warning about a mis-named Default.png file. This commit corrects it.

I'm willing to participate within the few free hours I have, as I am very interested in this project ;)
