### PR TITLE
Getting a touchscreen feeling

### DIFF
--- a/dosbox/src/gui/sdlmain.cpp
+++ b/dosbox/src/gui/sdlmain.cpp
@@ -1300,6 +1300,7 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button) {
 			GFX_CaptureMouse();
 			break;
 		}
+		Mouse_CursorSet(button->x, button->y);
 		switch (button->button) {
 		case SDL_BUTTON_LEFT:
 			Mouse_ButtonPressed(0);


### PR DESCRIPTION
Hi,
This is a proposition on a change on how input works for mouse, as touch heavy apps like RTS or simulation games are heavy on the mouse. The way it works now by touch and drag feels heavy and is absolutely not touch-friendly. I have no way to test it and would love your feedback on this !

When using a touchscreen device, it makes more sense to move the cursor
to touch position before doing the actual Mouse_ButtonPressed. I don't
see a UX where this change would be detrimental.

Thanks!
