### PR TITLE
Support for Bluetooth Keyboard under IOS9.

### DIFF
--- a/dospad/Shared/DosPadUIApplication.h
+++ b/dospad/Shared/DosPadUIApplication.h
@@ -10,6 +10,6 @@
 
 @interface DosPadUIApplication : UIApplication
 {
-	int lastEventFlags;
+	NSInteger lastEventFlags;
 }
 @end

--- a/dospad/Shared/DosPadUIApplication.m
+++ b/dospad/Shared/DosPadUIApplication.m
@@ -11,16 +11,21 @@
 
 extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 
-#define GSEVENT_TYPE 2
-#define GSEVENT_FLAGS 12
 #ifndef IS_IOS7
 #define IS_IOS7 ([[UIDevice currentDevice].systemVersion floatValue]>=7.0)
 #endif
-
+#ifndef IS_IOS9
+#define IS_IOS9 ([[UIDevice currentDevice].systemVersion floatValue]>=9.0)
+#endif
 #define IS_64BIT (sizeof(NSUInteger)==8)
-#define GSEVENTKEY_KEYCODE  (IS_64BIT?19:(IS_IOS7?17:15))
+
+#define GSEVENT_TYPE 2
+#define GSEVENT_FLAGS (IS_IOS9?10:12)
+
+#define GSEVENTKEY_KEYCODE  (IS_64BIT?(IS_IOS9?13:19):(IS_IOS7?17:15))
 #define GSEVENT_TYPE_KEYUP 11
 #define GSEVENT_TYPE_KEYDOWN 10
+
 #define GSEVENT_FLAG_LSHIFT 131072
 #define GSEVENT_FLAG_RSHIFT 2097152
 #define GSEVENT_FLAG_LCTRL 1048576
@@ -58,6 +63,43 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 }
 
 #ifndef APPSTORE
+
+- (void)DecodeKeyEvent:(NSInteger *)eventMem
+{
+    NSInteger eventType = eventMem[GSEVENT_TYPE];
+    NSInteger eventFlags = eventMem[GSEVENT_FLAGS];
+    //NSLog(@"event flags: %i type %d", eventFlags, eventType);
+    
+    if (lastEventFlags ^ eventFlags) {
+        [self onFlagsChange:eventFlags];
+        lastEventFlags = eventFlags;
+    }
+    
+    if (eventType == GSEVENT_TYPE_KEYUP) {
+        int scancode = eventMem[GSEVENTKEY_KEYCODE];
+        SDL_SendKeyboardKey(0, SDL_RELEASED, scancode);
+    }
+    
+    if(eventType == GSEVENT_TYPE_KEYDOWN)
+    {
+        int scancode = eventMem[GSEVENTKEY_KEYCODE];
+        SDL_SendKeyboardKey(0, SDL_PRESSED, scancode);
+    }
+}
+
+- (void)handleKeyUIEvent:(UIEvent *)event
+{
+    [super handleKeyUIEvent:event];
+    
+    if ([event respondsToSelector:@selector(_gsEvent)]) {
+        NSInteger *eventMem;
+        eventMem = (NSInteger *)[event performSelector:@selector(_gsEvent)];
+        if (eventMem) {
+            [self DecodeKeyEvent:eventMem];
+        }
+    }
+}
+
 - (void)sendEvent:(UIEvent *)event
 {
 	[super sendEvent:event];
@@ -65,27 +107,9 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 		int *eventMem;
 		eventMem = (int *)[event performSelector:@selector(_gsEvent)];
 		if (eventMem) {
-			int eventType = eventMem[GSEVENT_TYPE];
-			int eventFlags = eventMem[GSEVENT_FLAGS];
-			//NSLog(@"event flags: %i type %d", eventFlags, eventType);
-			
-			if (lastEventFlags ^ eventFlags) {
-				[self onFlagsChange:eventFlags];
-				lastEventFlags = eventFlags;
-			}
-			
-			if (eventType == GSEVENT_TYPE_KEYUP) {
-				int scancode = eventMem[GSEVENTKEY_KEYCODE];
-				SDL_SendKeyboardKey(0, SDL_RELEASED, scancode);
-			}
-			
-			if(eventType == GSEVENT_TYPE_KEYDOWN)
-			{
-				int scancode = eventMem[GSEVENTKEY_KEYCODE];
-				SDL_SendKeyboardKey(0, SDL_PRESSED, scancode);
-			}
-		}
-	}
+            [self DecodeKeyEvent:(NSInteger*)eventMem];
+        }
+    }
 }
 #endif
 


### PR DESCRIPTION
Support for Bluetooth Keyboard under IOS9.

Bluetooth keyboard support now working through “handleKeyUIEvent” as
opposed to “sendEvent” which no longer works. The code indicates it was
working for IOS7, but literature on the internet states apple moved
from sendEvent to hanldeKeyUIEvent as of IOS7.

All the GSEvent offsets have changed, I improved the code through using
NSInteger. As a result, I am not sure if I broke 32bit compilation (due
to offset differences with 64bit type). I am also not sure of the
specific offsets for IOS8 (sorry, don’t have a device to test on).

I suspect apple didn’t actually drastically change the offsets of the
GSEvent data structure, only some of the GSEvent internal types changed
to 64bit.

Disclaimer - green wrt IOS ;)