### PR TITLE
Added SmartKeyboard mappings

### DIFF
--- a/dospad/Settings.bundle/Root.plist
+++ b/dospad/Settings.bundle/Root.plist
@@ -36,7 +36,7 @@
 			<key>Key</key>
 			<string>key_sound_enabled</string>
 			<key>Title</key>
-			<string>Key Sound enabled</string>
+			<string>Key Sound Enabled</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -59,6 +59,16 @@
 			<string>Double Tap As Right Click</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Smart Keyboard Mappings (iPad)</string>
+			<key>Key</key>
+			<string>smart_keyboard_mappings</string>
+			<key>DefaultValue</key>
+			<false/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/dospad/Shared/Common.h
+++ b/dospad/Shared/Common.h
@@ -40,6 +40,7 @@
 #define kDoubleTapAsRightClick @"double_tap_as_right_click"
 #define kGamePadSoundEnabled   @"gamepad_sound_enabled"
 #define kDPadMovable           @"dpad_movable"
+#define kSmartKeyboardMappings @"smart_keyboard_mappings"
 #define kNumpadEnabled         @"numpad_enabled"
 #define kJoystickEnabled       @"joystick_enabled"
 #define KWebServerEnabled      @"httpd_enabled"

--- a/dospad/Shared/DosPadUIApplication.m
+++ b/dospad/Shared/DosPadUIApplication.m
@@ -7,6 +7,7 @@
 //
 
 #import "DosPadUIApplication.h"
+#include "Common.h"
 #include "keys.h"
 
 extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
@@ -19,23 +20,23 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 #endif
 #define IS_64BIT (sizeof(NSUInteger)==8)
 
-#define GSEVENT_TYPE    2
-#define GSEVENT_FLAGS   (IS_64BIT?10:12)
+#define GSEVENT_TYPE            2
+#define GSEVENT_FLAGS           (IS_64BIT?10:12)
 
-#define GSEVENTKEY_KEYCODE  (IS_64BIT?(IS_IOS9?13:19):(IS_IOS7?17:15))
+#define GSEVENTKEY_KEYCODE      (IS_64BIT?(IS_IOS9?13:19):(IS_IOS7?17:15))
 
-#define GSEVENT_TYPE_KEYUP   11
-#define GSEVENT_TYPE_KEYDOWN 10
-#define GSEVENT_TYPE_MODIFER 12
+#define GSEVENT_TYPE_KEYUP      11
+#define GSEVENT_TYPE_KEYDOWN    10
+#define GSEVENT_TYPE_MODIFIER   12
 
-#define GSEVENT_FLAG_LCMD   65536           // 0x00010000
-#define GSEVENT_FLAG_LSHIFT 131072          // 0x00020000
-#define GSEVENT_FLAG_LCTRL  1048576         // 0x00100000
-#define GSEVENT_FLAG_LALT   524288          // 0x00080000
+#define GSEVENT_FLAG_LCMD       65536           // 0x00010000
+#define GSEVENT_FLAG_LSHIFT     131072          // 0x00020000
+#define GSEVENT_FLAG_LCTRL      1048576         // 0x00100000
+#define GSEVENT_FLAG_LALT       524288          // 0x00080000
 
-#define GSEVENT_FLAG_RSHIFT 2097152         // 0x00200000 - not sent IOS9
-#define GSEVENT_FLAG_RCTRL  8388608         // 0x00800000 - not sent IOS9
-#define GSEVENT_FLAG_RALT   4194304         // 0x00400000 - not sent IOS9
+#define GSEVENT_FLAG_RSHIFT     2097152         // 0x00200000 - not sent IOS9
+#define GSEVENT_FLAG_RCTRL      8388608         // 0x00800000 - not sent IOS9
+#define GSEVENT_FLAG_RALT       4194304         // 0x00400000 - not sent IOS9
 
 
 @implementation DosPadUIApplication
@@ -71,27 +72,47 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 - (void)decodeKeyEvent:(NSInteger *)eventMem
 {
     NSInteger eventType  = eventMem[GSEVENT_TYPE];                  // See GS_EVENTYPE_*
-    NSInteger eventModfier = eventMem[GSEVENT_FLAGS];               // Indicate bitmask of 'modifiers pressed', where modifiers are SHIFT/CTRL/ALT/CAPS/WINKEY/CAPS/ETC (note, only LEFT macros above are actually sent on IOS9).
+    NSInteger eventModifier = eventMem[GSEVENT_FLAGS];              // Indicate bitmask of 'modifiers pressed', where modifiers are SHIFT/CTRL/ALT/CAPS/WINKEY/CAPS/ETC (note, only LEFT macros above are actually sent on IOS9).
     NSInteger eventScanCode = eventMem[GSEVENTKEY_KEYCODE];         // ScanCode.
     NSInteger eventLastModifer = lastEventFlags;                    // Previous (last) modifer - used for bitmask detection of released.
     
-    if(!IS_IOS9) { // preserved for backward compatiblity
-        if (lastEventFlags ^ eventModfier) {
-            [self onFlagsChange:eventModfier];
-            lastEventFlags = eventModfier;
+        // For SmartKeyboard (iPad Pro)
+    if (DEFS_GET_INT(kSmartKeyboardMappings) == 1) {
+            // Map GRAVE(TILDE) to ESCAPE (CMD-GRAVE = GRAVE)
+        if(eventScanCode == SDL_SCANCODE_GRAVE) {
+            if(!(eventModifier & GSEVENT_FLAG_LCMD))
+                eventScanCode = SDL_SCANCODE_ESCAPE;
+            else
+                eventModifier &= ~GSEVENT_FLAG_LCMD;
+        }
+    
+            // Map CMD-1->0 to FN1->F10
+        if(eventModifier & GSEVENT_FLAG_LCMD &&
+            eventScanCode >= SDL_SCANCODE_1 &&
+            eventScanCode <= SDL_SCANCODE_0) {
+        
+            eventScanCode = SDL_SCANCODE_F1 + (eventScanCode-SDL_SCANCODE_1);
+            eventModifier &= ~GSEVENT_FLAG_LCMD;
         }
     }
-
+    
+    if(!IS_IOS9) { // preserved for backward compatiblity
+        if (lastEventFlags ^ eventModifier) {
+            [self onFlagsChange:eventModifier];
+            lastEventFlags = eventModifier;
+        }
+    }
+    
     bool pressed = false;
     if (eventType == GSEVENT_TYPE_KEYUP) {
         SDL_SendKeyboardKey(0, SDL_RELEASED, (int)eventScanCode);
     } else if(eventType == GSEVENT_TYPE_KEYDOWN) {
         SDL_SendKeyboardKey(0, SDL_PRESSED, (int)eventScanCode);
         pressed = true;
-    } else if(IS_IOS9 && eventType == GSEVENT_TYPE_MODIFER) {       // Send modifier as pure scancode, with PRESSED/RELEASED derived from eventModfier ('keydown' bitmask state).
-        pressed = (eventModfier != 0 && eventModfier>eventLastModifer);
+    } else if(IS_IOS9 && eventType == GSEVENT_TYPE_MODIFIER) {       // Send modifier as pure scancode, with PRESSED/RELEASED derived from eventModfier ('keydown' bitmask state).
+        pressed = (eventModifier != 0 && eventModifier>eventLastModifer);
         SDL_SendKeyboardKey(0, pressed?SDL_PRESSED:SDL_RELEASED, (int)eventScanCode);
-        lastEventFlags = eventModfier;
+        lastEventFlags = eventModifier;
     }
     
     //NSLog(@"event type<%d>[%ld] code<%d>[%ld] flags<%d>[%ld|0x%08X] lastFlags[%ld|0x%08X] state[%s]", GSEVENT_TYPE, (long)eventType, GSEVENTKEY_KEYCODE, (long)eventScanCode, GSEVENT_FLAGS, (long)eventModfier, (unsigned int)eventModfier, (long)eventLastModifer, (unsigned int)eventLastModifer, pressed?"PRESSED":"RELEASED");


### PR DESCRIPTION
Since the iPadPro SmartKeyboard does not have an escape key or function keys, a switch was added to map the following: -
* GRAVE(TILDE) to ESCAPE, this behaviour can be reverted by CMD-GRAVE.
* CMD1->0 to FN1->FN10 - note the initial and trailing CMD key events are not filter (this might be an improvement in the future).
Also cleaned up the keyboard handling code further (typos/etc).