### PR TITLE
iOS 13 fix: call makeKeyAndVisible on main thread to prevent crash

### DIFF
--- a/SDL/src/video/uikit/SDL_uikitopengles.m
+++ b/SDL/src/video/uikit/SDL_uikitopengles.m
@@ -84,7 +84,9 @@ void UIKit_GL_SwapWindow(_THIS, SDL_Window * window)
 	[data->view swapBuffers];
 	/* since now we've got something to draw
 	   make the window visible */
-	[data->uiwindow makeKeyAndVisible];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [data->uiwindow makeKeyAndVisible];
+    });
 
 	/* we need to let the event cycle run, or the OS won't update the OpenGL view! */
 	SDL_PumpEvents();


### PR DESCRIPTION
Addresses #77 - had to close previous pull request because my fork got messed up.

There were some changes in the windowing system and startup with the new scene delegate in iOS 13 so I'm thinking this breaks stuff in this (customized?) SDL library in this repo. I didn't have any issues in other projects with SDL2 in iOS 13.