### PR TITLE
Feature/pointersupport

### DIFF
--- a/SDL/src/video/uikit/SDL_uikitview.h
+++ b/SDL/src/video/uikit/SDL_uikitview.h
@@ -85,7 +85,8 @@ typedef struct {
 	UITextField *textField;
 	BOOL keyboardVisible;
 #endif	
-    
+    SDL_Mouse * pointerMouse; /* mouse for ipadOS pointer interaction */
+    BOOL pointerNeedsCalibration;
 }
 #ifdef IPHONEOS
 @property (nonatomic,assign)  id<MouseHoldDelegate> mouseHoldDelegate;
@@ -106,5 +107,11 @@ typedef struct {
 @property (readonly) BOOL keyboardVisible;
 #endif 
 
+- (void)initializeMice;
+
+#ifdef IPHONEOS
+- (void)sendPointerLocation:(CGPoint)point;
+- (void)calibratePointer;
+#endif
 @end
 /* *INDENT-ON* */

--- a/dospad/Shared/DOSPadBaseViewController.h
+++ b/dospad/Shared/DOSPadBaseViewController.h
@@ -38,12 +38,13 @@ typedef enum {
 } InputSourceType;
 
 @interface DOSPadBaseViewController : UIViewController
-<SDL_uikitopenglview_delegate,MouseHoldDelegate,KeyDelegate,UIAlertViewDelegate>
+<SDL_uikitopenglview_delegate,MouseHoldDelegate,KeyDelegate,UIPointerInteractionDelegate,UIAlertViewDelegate>
 {
     NSString *configPath;
     BOOL autoExit;
     SDL_uikitopenglview *screenView;
     HoldIndicator *holdIndicator;
+    UIPointerInteraction* interaction;
     
     // Input Devices
     //VKView *vk; // Background, conflicts with iOS keyboard
@@ -91,4 +92,8 @@ typedef enum {
 - (void)createJoystick;
 - (void)createMouseButtons;
 - (void)createPianoKeyboard;
+
+- (UIPointerRegion *)pointerInteraction:(UIPointerInteraction *)interaction regionForRequest:(UIPointerRegionRequest *)request defaultRegion:(UIPointerRegion *)defaultRegion  API_AVAILABLE(ios(13.4));
+
+extern const int POINTER_INTERACTION_SDL_MOUSE_ID;
 @end

--- a/dospad/Shared/DOSPadBaseViewController.m
+++ b/dospad/Shared/DOSPadBaseViewController.m
@@ -193,9 +193,9 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
         
     }];
     
-    // adding pointer interaction delegate
+    // setup pointer interaction
     interaction = [[UIPointerInteraction alloc] initWithDelegate: self];
-    [self.view addInteraction:interaction];
+    [self.screenView addInteraction:interaction];
 }
 
 
@@ -261,55 +261,11 @@ extern int SDL_SendKeyboardKey(int index, Uint8 state, SDL_scancode scancode);
 }
 
 - (UIPointerRegion *)pointerInteraction:(UIPointerInteraction *)interaction regionForRequest:(UIPointerRegionRequest *)request defaultRegion:(UIPointerRegion *)defaultRegion  API_AVAILABLE(ios(13.4)){
-        
-    // ensure a SDL_mouse for physical pointerInteraction
-    // TODO: if mouse created here before screenView creates, screenview don't create its own mice. Need to improve (there)
-    Boolean mouseReady = false;
-    for(int i=0; i < SDL_GetNumMice(); i++) {
-        if (SDL_GetMouse(i)->id == POINTER_INTERACTION_SDL_MOUSE_ID) {
-            mouseReady = true;
-            break;
+        if (request != nil) {
+            CGPoint loc = request.location;
+            [self.screenView sendPointerLocation:loc];
         }
-    }
-    
-    if(!mouseReady) {
-        SDL_Mouse * mouse = (SDL_Mouse*) calloc(1, sizeof(SDL_Mouse));
-        mouse->id= POINTER_INTERACTION_SDL_MOUSE_ID;
-        SDL_AddMouse(mouse, "physical pointer", 0, 0, 1);
-    }
-    
-    if (request != nil) {
-        CGPoint loc = request.location;
-        NSLog(@"Interaction: x: %f, y: %f", loc.x, loc.y);
-        float inscreenX = loc.x - screenView.frame.origin.x;
-        float inscreenY = loc.y - screenView.frame.origin.y;
-        NSLog(@"inScreen: x: %f, y: %f", inscreenX, inscreenY);
-        
-        float boundWidth = screenView.bounds.size.width;
-        float boundHeight = screenView.bounds.size.height;
-        NSLog(@"bound: w: %f, h: %f", boundWidth, boundHeight);
-        
-        float frameWidth = screenView.frame.size.width;
-        float frameHeight = screenView.frame.size.height;
-        NSLog(@"frame: w: %f, h: %f", frameWidth, frameHeight);
-
-        float ratioPosX = inscreenX / frameWidth;
-        float ratioPosY = inscreenY / frameHeight;
-        NSLog(@"ratioPos: x: %f, y: %f", ratioPosX, ratioPosY);
-
-        
-        float convertedX = boundWidth * ratioPosX;
-        float convertedY = boundHeight * ratioPosY;
-        NSLog(@"Converted: x: %f, y: %f", convertedX, convertedY);
-        // send mouse motion with calculated absolute mouse position
-        // note multiplication by 2, which seems to be required for SDL Screen size
-        // use mouse 0
-//        SDL_SetRelativeMouseMode(0, SDL_FALSE);
-//        SDL_SendMouseMotion(0, 0, convertedX*2, convertedY*2, 0);
-//        SDL_SetRelativeMouseMode(0, SDL_TRUE);
-        SDL_SendMouseMotion(POINTER_INTERACTION_SDL_MOUSE_ID, 0, convertedX*2, convertedY*2, 0);
-    }
-    return nil;
+        return nil;
 }
 
 -(BOOL)onDoubleTap:(CGPoint)pt

--- a/dospad/iPad/DosPadViewController.h
+++ b/dospad/iPad/DosPadViewController.h
@@ -30,7 +30,7 @@
 #import "FloatPanel.h"
 
 @interface DosPadViewController : DOSPadBaseViewController
-<FloatingViewDelegate>
+<UIPointerInteractionDelegate, FloatingViewDelegate>
 {
     // Portrait Mode
     FrameskipIndicator *fsIndicator;

--- a/dospad/iPad/DosPadViewController.m
+++ b/dospad/iPad/DosPadViewController.m
@@ -469,6 +469,7 @@ static struct {
     [self updateBackground];    
     if ([self isFullscreen]) 
     {
+        baseView.userInteractionEnabled = NO;
         [self.view insertSubview:self.screenView atIndex:0];
         keyboard.alpha=0;
         sliderInput.alpha=0;
@@ -506,6 +507,8 @@ static struct {
     }
     else 
     {
+        baseView.userInteractionEnabled = YES;
+        [self.screenView removeFromSuperview];
         [baseView insertSubview:self.screenView atIndex:0];
 		
 		// Scaling baseView to fill self.view as much as possible

--- a/dospad/iPad/DosPadViewController.m
+++ b/dospad/iPad/DosPadViewController.m
@@ -469,7 +469,6 @@ static struct {
     [self updateBackground];    
     if ([self isFullscreen]) 
     {
-        baseView.userInteractionEnabled = NO;
         [self.view insertSubview:self.screenView atIndex:0];
         baseView.alpha = 0;
         keyboard.alpha=0;
@@ -508,7 +507,6 @@ static struct {
     }
     else 
     {
-        baseView.userInteractionEnabled = YES;
         [self.screenView removeFromSuperview];
         [baseView insertSubview:self.screenView atIndex:0];
 		baseView.alpha = 1;

--- a/dospad/iPad/DosPadViewController.m
+++ b/dospad/iPad/DosPadViewController.m
@@ -545,6 +545,8 @@ static struct {
     {
         [self addInputSource:InputSource_Joystick];
     }
+    
+    [self.screenView calibratePointer];
 }
 
 -(void)viewWillAppear:(BOOL)animated

--- a/iDOS-Info.plist
+++ b/iDOS-Info.plist
@@ -34,13 +34,17 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>20171230.1132</string>
+	<string>20200821.0739</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>
 	<string>MainWindow</string>
 	<key>NSMainNibFile~ipad</key>
 	<string>MainWindow</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Hello litchie!

Here's a working version of bluetooth mouse support that I worked on recently ... oh wait!! I've been working on bluetooth mouse support last week, and now have a good working version. I was about to create a pull request to initiate discussion...  --- but then I realize that you've actually committed the new change! Nonetheless, I've made the pull request, just to discuss some features that are currently missed, or different in your upstream master. 

Let me briefly describe the content of pull request first.  
- Mouse point works correctly in absolute-point mode for both full screen and portrait mode -- iPadOs pointer icon syncs exactly with in-dos pointer location. 
   - Mouse movements are captured via *UIPointerInteractionDelegate* of screenView (I've put the delegate on DosPadBaseViewController) 
   - Actual event passing is done in screenView(SDL_UIKitView), by newly added absolute mouse position passing code. Note that, here I had to do some trick (such as forced calibration of sending min - max values at screen size change), to make sure IPadOS pointer location to exactly match 
- Left / Right click works. 
   - This is delivered as touch information via *UIApplicationSupportsIndirectInputEvents* enabled. The touch with *touch.type == UITouchTypeIndirectPointer*. When we get it, Left/Right key is also sent via *event.buttonmask*, so the code uses it. 

Basically, that's it. I've tested this on the sim and my iPadPro, ... well, and I think this is nearly feature complete. I know you already rewrote touch code greatly, but some part of my approach may be interesting to you. 
- making mouse pointer to work in absolute mode -- dos mouse pointer  syncs exactly with iPadOS pointer to its corresponding location on screen (e.g. calibration hack, etc.)
- left / right mouse button recognition is there with 

Some remaining / unclear / hacky parts on this pull request 
- Hiding / not hiding iPadOs pointer icon (currently showing for dev / debug)
- fixed scaling, at absolute mode mouse location passing from screenView to SDL mouse event coordination -- currently fixed as * 2.0 -- this works exact match, and I still have no idea why this has to be 2.0. 
- "calibration hack": currently, exact pointer match is possible with this hack. But there maybe a better way to do this? 

====

So, I guess you will not accept this pull_request, Since you have already fully rewrote the touch base on SDL_UIKitView. 

I am wondering what type of help i can provide to you :-) e.g. add right click support maybe? --- note that I have not tested your latest bluetooth mouse support yet... 

At any rate, let me thank you for this wonderful DosPad source code base. For me, this code hack was for my own joy to run wonderful 90s role-playing games such as Might&Magic 3, or Eye of the Beholder series with good mouse support. And I am enjoying it greatly. Thanks! --- Let me know if you have some idea how can I help you on this mouse feature set, or any other stuff. 