### PR TITLE
Issue #117) Mapped Pencil 2 tap gesture to mouse right-click.

### DIFF
--- a/dospad/Main/DPEmulatorViewController.h
+++ b/dospad/Main/DPEmulatorViewController.h
@@ -49,4 +49,5 @@ typedef enum {
 -(void)updateCpuCycles:(NSString*)title;
 -(void)willResignActive;
 -(void)didBecomeActive;
+-(void)pencilInteractionDidTap:(UIPencilInteraction*)interaction API_AVAILABLE(ios(12.1));
 @end

--- a/dospad/Main/DPEmulatorViewController.m
+++ b/dospad/Main/DPEmulatorViewController.m
@@ -67,7 +67,8 @@ static struct {
     DPMouseManagerDelegate,
     DPKeyboardManagerDelegate,
 	MfiGamepadManagerDelegate,
-	MfiGamepadMapperDelegate
+	MfiGamepadMapperDelegate,
+    UIPencilInteractionDelegate
 >
 {
 	MfiGamepadConfiguration *_mfiConfig;
@@ -569,8 +570,19 @@ static struct {
 			[sceneContainer addSubview:btn];
 		}
 	}
+    // Pencil gesture support
+    if (@available(iOS 12.1, *)) {
+        UIPencilInteraction *pencilInteraction = [[UIPencilInteraction alloc] init];
+        pencilInteraction.delegate = self;
+        [self.view addInteraction:pencilInteraction];
+    }
 	return sceneContainer;
+}
 
+- (void)pencilInteractionDidTap:(UIPencilInteraction *)interaction API_AVAILABLE(ios(12.1)){
+    //NSLog(@"Pencil double tap gesture detected");
+    [self.screenView sendMouseEvent:0 left:NO down:YES];
+    [self.screenView sendMouseEvent:0 left:NO down:NO];
 }
 
 - (void)viewWillLayoutSubviews

--- a/dospad/Main/DPEmulatorViewController.m
+++ b/dospad/Main/DPEmulatorViewController.m
@@ -570,12 +570,6 @@ static struct {
 			[sceneContainer addSubview:btn];
 		}
 	}
-    // Pencil gesture support
-    if (@available(iOS 12.1, *)) {
-        UIPencilInteraction *pencilInteraction = [[UIPencilInteraction alloc] init];
-        pencilInteraction.delegate = self;
-        [self.view addInteraction:pencilInteraction];
-    }
 	return sceneContainer;
 }
 
@@ -757,6 +751,13 @@ static struct {
         [self.view addSubview:self.kbdspy];
     }
 #endif
+    
+    // Pencil 2 gesture support
+    if (@available(iOS 12.1, *)) {
+        UIPencilInteraction *pencilInteraction = [[UIPencilInteraction alloc] init];
+        pencilInteraction.delegate = self;
+        [self.view addInteraction:pencilInteraction];
+    }
 
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didSettingsChanged:) name:DPFSettingsChangedNotification object:nil];
 }


### PR DESCRIPTION
As suggested in #117 , I've mapped the 'double tap' gesture on Pencil 2 to right-clicking with the mouse.

I've tested this on an iPad Air (4th gen) and it works.

I'm not really across the app structure, so I've implemented this the simplest way I could. Let me know if the gesture handling should be somewhere else rather than the main controller.