### PR TITLE
Allow Apple Music to play while using dospad

### DIFF
--- a/dospad/Main/AppDelegate.m
+++ b/dospad/Main/AppDelegate.m
@@ -184,7 +184,7 @@
 	NSError *setCategoryErr = nil;
 	NSError *activationErr  = nil;
 	[[AVAudioSession sharedInstance]
-		setCategory: AVAudioSessionCategoryPlayback
+		setCategory: AVAudioSessionCategoryAmbient
 		error: &setCategoryErr];
 	[[AVAudioSession sharedInstance]
 		setActive: YES


### PR DESCRIPTION
Can be nice depending on what you're doing to be able to listen to your device's music library while using the app.  Setting the AVAudioSession category to Ambient allows that while still letting dos games play their sfx.  Also still respects the silent button.

Tested on an iPhone 12